### PR TITLE
Redirect to root path when new shift request error

### DIFF
--- a/app/views/members/_form.html.haml
+++ b/app/views/members/_form.html.haml
@@ -5,9 +5,3 @@
       %ul
         - @member.errors.full_messages.each do |msg|
           %li= msg
-  .field
-    = f.label '名前'
-    = f.text_field :name
-
-  .actions
-    = f.submit '保存'

--- a/app/views/members/edit.html.haml
+++ b/app/views/members/edit.html.haml
@@ -1,7 +1,4 @@
-%h1 名前の編集
-
 = render 'form'
 
-= link_to '申請の一覧', @member
-\|
-= link_to 'メンバー一覧へ戻る', members_path
+%div= link_to '申請に戻る', new_shift_request_path(member_id: @member.id)
+%div= link_to 'ホームに戻る', root_path


### PR DESCRIPTION
シフト申請に失敗した時に、Members#editが呼ばれてMemberの編集画面になってしまっているのを解決しているっぽい見た目にした。
けどこの場合、失敗したまま。
申請ももう一回やり直すか、あきらめてルートへ行く。
