### PR TITLE
土日祝日のシフトの変化に対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
+gem 'holiday_jp'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    holiday_jp (0.4.3)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
@@ -195,6 +196,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   factory_girl_rails
   haml-rails
+  holiday_jp
   jbuilder (~> 2.0)
   jquery-rails
   pg

--- a/app/assets/javascripts/shift_request.js
+++ b/app/assets/javascripts/shift_request.js
@@ -1,0 +1,49 @@
+$(function(){
+    $(".cancel-button").on("click", function(event){
+        var dataIndex = $(event.target).data("index")
+        $("#member_shift_requests_attributes_" + dataIndex + "_slot_0").attr("checked",false);
+        $("#member_shift_requests_attributes_" + dataIndex + "_slot_1").attr("checked",false);
+        $("#member_shift_requests_attributes_" + dataIndex + "_slot_2").attr("checked",false);
+        $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val('');
+        $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val('');
+        $("#member_shift_requests_attributes_" + dataIndex + "_comment").val('');
+    });
+});
+
+$(function(){
+    $(".slot-0").on("click", function(event){
+        var dataIndex = $(event.target).data("index");
+        var holiday = ($("#member_shift_requests_attributes_" + dataIndex + "_date").hasClass("holiday"));
+        if (holiday) {
+            console.log("holiday");
+            $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val("1000");
+            $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val("1600");
+        } else {
+            console.log("NOT holiday");
+            $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val("1000");
+            $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val("1900");
+        };
+    });
+});
+
+$(function(){
+    $(".slot-1").on("click", function(event){
+        var dataIndex = $(event.target).data("index")
+        var holiday = ($("#member_shift_requests_attributes_" + dataIndex + "_date").hasClass("holiday"));
+        if (holiday) {
+            $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val("1600");
+            $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val("2200");
+        } else {
+            $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val("1300");
+            $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val("2200");
+        };
+    });
+});
+
+$(function(){
+    $(".slot-2").on("click", function(event){
+        var dataIndex = $(event.target).data("index")
+        $("#member_shift_requests_attributes_" + dataIndex + "_start_time").val("2200");
+        $("#member_shift_requests_attributes_" + dataIndex + "_end_time").val("1000");
+    });
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -66,3 +66,6 @@ table {
     border-bottom: solid 1px #C8CDD0;
   }
 }
+label.holiday {
+  color: #FF4000;
+}

--- a/app/controllers/shift_requests_controller.rb
+++ b/app/controllers/shift_requests_controller.rb
@@ -28,6 +28,7 @@ class ShiftRequestsController < ApplicationController
     @request_days.count.times { @member.shift_requests.build }
     # Where should we write this array?
     @time_select = %w(1000 1030 1100 1130 1200 1230 1300 1330 1400 1430 1500 1530 1600 1630 1700 1730 1800 1830 1900 1930 2000 2030 2100 2130 2200 2230 2300 2330 0000 0030 0100 0130 0200 0230 0300 0330 0400 0430 0500 0530 0600 0630 0700 0730 0800 0830 0900 0930)
+    @national_holidays = HolidayJp.between(@request_days.to_a[0], @request_days.to_a[-1])
   end
 
   # GET /shift_requests/1/edit

--- a/app/helpers/shift_requests_helper.rb
+++ b/app/helpers/shift_requests_helper.rb
@@ -1,5 +1,5 @@
 module ShiftRequestsHelper
-  def weekend?(day)
-    day.wday == 0 || day.wday == 6
+  def holiday?(day)
+    day.wday == 0 || day.wday == 6 || @national_holidays.any? {|d| d.date == day }
   end
 end

--- a/app/helpers/shift_requests_helper.rb
+++ b/app/helpers/shift_requests_helper.rb
@@ -1,2 +1,5 @@
 module ShiftRequestsHelper
+  def weekend?(day)
+    day.wday == 0 || day.wday == 6
+  end
 end

--- a/app/views/shift_requests/_form.html.haml
+++ b/app/views/shift_requests/_form.html.haml
@@ -12,11 +12,29 @@
   %table
     %thead
       %tr
+        %th 平日
+        %th 土日祝
+    %tbody
+      %tr
+        %td 早番（10:00〜19:00）
+        %td 早番（10:00〜16:00）
+    %tbody
+      %tr
+        %td 遅番（13:00〜22:00）
+        %td 遅番（16:00〜22:00）
+    %tbody
+      %tr
+        %td 泊り（22:00〜10:00）
+        %td 泊り（22:00〜10:00）
+
+  %table
+    %thead
+      %tr
         %th 日付
         %th 曜日
-        %th 早番（10:00〜19:00）
-        %th 遅番（13:00〜22:00）
-        %th 泊り（22:00〜10:00）
+        %th 早番
+        %th 遅番
+        %th 泊り
         %th 開始時間
         %th 終了時間
         %th コメント
@@ -26,26 +44,15 @@
         %tr
           - shift_request_form.text_field :member_id, value: @member.id
           - request_day = @request_days.to_a[shift_request_form.index]
-          %td= shift_request_form.date_field :date, value: request_day, readonly: true
+          %td= shift_request_form.date_field :date, value: request_day, readonly: true, class: ("holiday" if weekend?(request_day))
           %td= request_day.strftime("#{%w(日 月 火 水 木 金 土)[request_day.wday]}")
-          %td= shift_request_form.radio_button :slot, 0
-          %td= shift_request_form.radio_button :slot, 1
-          %td= shift_request_form.radio_button :slot, 2
+          %td= shift_request_form.radio_button :slot, 0, class: "slot-0", "data-index" => shift_request_form.index
+          %td= shift_request_form.radio_button :slot, 1, class: "slot-1", "data-index" => shift_request_form.index
+          %td= shift_request_form.radio_button :slot, 2, class: "slot-2", "data-index" => shift_request_form.index
           %td= shift_request_form.select :start_time, @time_select, include_blank: true
           %td= shift_request_form.select :end_time, @time_select, include_blank: true
           %td= shift_request_form.text_field :comment, size: 30
           %td= link_to 'Cancel', "#", class: "cancel-button", "data-index" => shift_request_form.index
-
-    :javascript
-      $(function(){
-        $(".cancel-button").on("click", function(event){
-        var dataIndex = $(event.target).data("index")
-        $("#member_shift_requests_attributes_" + dataIndex + "_slot_0").attr("checked",false);
-        $("#member_shift_requests_attributes_" + dataIndex + "_slot_1").attr("checked",false);
-        $("#member_shift_requests_attributes_" + dataIndex + "_slot_2").attr("checked",false);
-        $("#member_shift_requests_attributes_" + dataIndex + "_comment").val('');
-        });
-      });
 
   .actions
     = f.submit 'Save'

--- a/app/views/shift_requests/_form.html.haml
+++ b/app/views/shift_requests/_form.html.haml
@@ -44,8 +44,8 @@
         %tr
           - shift_request_form.text_field :member_id, value: @member.id
           - request_day = @request_days.to_a[shift_request_form.index]
-          %td= shift_request_form.date_field :date, value: request_day, readonly: true, class: ("holiday" if weekend?(request_day))
-          %td= request_day.strftime("#{%w(日 月 火 水 木 金 土)[request_day.wday]}")
+          %td= shift_request_form.date_field :date, value: request_day, readonly: true, class: ("holiday" if holiday?(request_day))
+          %td= label_tag request_day.strftime("#{%w(日 月 火 水 木 金 土)[request_day.wday]}"), nil, class: ("holiday" if holiday?(request_day))
           %td= shift_request_form.radio_button :slot, 0, class: "slot-0", "data-index" => shift_request_form.index
           %td= shift_request_form.radio_button :slot, 1, class: "slot-1", "data-index" => shift_request_form.index
           %td= shift_request_form.radio_button :slot, 2, class: "slot-2", "data-index" => shift_request_form.index


### PR DESCRIPTION
fix #14 #15 
早番のチェックボックスをクリックすると、デフォルトの早番の時間が、`開始時間` `終了時間` が入るようにしました。
土日祝を判定していて、それのシフト時間にも対応しています。
たとえば土曜日の早番をクリックすれば、10~16時になる。
あと土日祝の曜日が赤くなるようにCSSも書き足したけど、
デザイン的にいかがなものか。

:eyes: @yukari8 
